### PR TITLE
Strip non-printable characters from token to support newer Ruby versions

### DIFF
--- a/github
+++ b/github
@@ -34,7 +34,8 @@ class Github
   private
 
   def load_token!
-    @token, err, st = Open3.capture3("security find-generic-password -a $USER -s #{KEYCHAIN_ENTRY} -w")
+    token, err, st = Open3.capture3("security find-generic-password -a $USER -s #{KEYCHAIN_ENTRY} -w")
+    @token = strip_non_printable_characters(token)
     if !st.success?
       raise AuthenticationError.new("Keychain entry not found. Use gh-auth to fix this.")
     elsif !@token || @token.empty?
@@ -97,6 +98,10 @@ class Github
       raise APIError.new("Error communicating with Github. Details: GET #{path} #{response_code}")
     end
     JSON.parse(response.body)
+  end
+
+  def strip_non_printable_characters(string)
+    string.gsub(/[^[:print:]]/i, '')
   end
 end
 


### PR DESCRIPTION
- The token, when loaded from Mac OS, has a `CR/LF` at the end
- This breaks the requests to Github in most (all?) Ruby versions > 2.3.3.
- Stripping non-printable characters from the token before using it makes this problem go away. Tested with Ruby 2.5.1

Error message:

`header field value cannot include CR/LF (ArgumentError)`

```
❯ ruby --version
ruby 2.5.1p57 (2018-03-29 revision 63029) [x86_64-darwin17]
❯ ls -alt .user-cache
-rw-r--r-- 1 ryanbrushett staff 37 Jun  8 16:46 .user-cache
❯ ./github --refresh
Successfully refreshed user cache
❯ ls -alt .user-cache
-rw-r--r-- 1 ryanbrushett staff 37 Jun  8 16:47 .user-cache
```

@KnVerey 